### PR TITLE
Forgo reasoning about DDL replication on FAQ

### DIFF
--- a/Bucardo/FAQ.md
+++ b/Bucardo/FAQ.md
@@ -49,7 +49,7 @@ There is no simple answer to this question, as it depends on how many tables you
 
 ### Can Bucardo replicate DDL?
 
-No, Bucardo relies on triggers, and Postgres does not yet provide DDL triggers or triggers on its system tables.
+No
 
 ### What does "Could not add to q" mean
 


### PR DESCRIPTION
It was claiming that Postgres doesn't have DDL triggers, but Postgres does have them since version 9.3.
